### PR TITLE
Added searching by category

### DIFF
--- a/src/AmazonECS.php
+++ b/src/AmazonECS.php
@@ -48,13 +48,14 @@ class AmazonECS
 	 * Amazon Product Advertisting API - ItemSearch
 	 * 
 	 * @param  string $query
+	 * @param  string $category
 	 * @return response
 	 */
-	public function search($query)
+	public function search($query, $category = 'All')
 	{
+		
 		$query		= rawurlencode($query);
-		$params 	= $this->params(['Keywords' => $query, 'SearchIndex' => 'All', 'ResponseGroup' => $this->response_group]);
-		$string 	= $this->buildString($params);
+		$params 	= $this->params(['Keywords' => $query, 'SearchIndex' => $category, 'ResponseGroup' => 'Images,ItemAttributes']);		$string 	= $this->buildString($params);
 		$signature 	= $this->signString($string);
 		$url 		= $this->url($params, $signature);
 


### PR DESCRIPTION
Added support for searching by category.
the usage should be like the code below if you want to search by a category, the name of the categories should be the same as written on Amazon and I think most of them there first letters are uppercase.
`$results = Amazon::search('Home Alone', 'Electronics')->json();`
And if you didn't write the second parameter it will search in 'All' categories.
I hope it's useful.
Thanks